### PR TITLE
Several improvements to txt2vid

### DIFF
--- a/configs/webui/webui_streamlit.yaml
+++ b/configs/webui/webui_streamlit.yaml
@@ -19,7 +19,7 @@
 # You may add overrides in a file named "userconfig_streamlit.yaml" in this folder, which can contain any subset
 # of the properties below.
 general:
-    version: 1.20.0
+    version: 1.24.6
     streamlit_telemetry: False
     default_theme: dark
     huggingface_token: ''
@@ -212,7 +212,7 @@ txt2vid:
         format:     "%.5f"
 
     beta_scheduler_type: "scaled_linear"
-    max_frames: 100
+    max_duration_in_seconds: 30
 
     LDSR_config:
         sampling_steps: 50

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,10 +36,14 @@ hydralit_components==1.0.10
 stqdm==0.0.4
 uvicorn
 fastapi
+#jsonmerge==1.8.
+#matplotlib==3.6.
+#resize-right==0.0.2
+#torchdiffeq==0.2.3
 
 # txt2vid
 stable-diffusion-videos==0.5.3
-diffusers==0.4
+diffusers==0.6.0
 librosa==0.9.2
 
 # img2img inpainting

--- a/scripts/Settings.py
+++ b/scripts/Settings.py
@@ -684,8 +684,8 @@ def layout():
                 st.session_state["defaults"].txt2vid.do_loop = st.checkbox("Loop Generations", value=st.session_state['defaults'].txt2vid.do_loop,
                                                                            help="Choose to loop or something, IDK.... Default: False")
 
-                st.session_state["defaults"].txt2vid.max_frames = st.number_input("Txt2Vid Max Video Frames", value=st.session_state['defaults'].txt2vid.max_frames,
-                                                                                  help="Set the default value for the number of video frames generated. Default is: 100")
+                st.session_state["defaults"].txt2vid.max_duration_in_seconds = st.number_input("Txt2Vid Max Duration in Seconds", value=st.session_state['defaults'].txt2vid.max_duration_in_seconds,
+                                                                                  help="Set the default value for the max duration in seconds for the video generated. Default is: 30")
 
                 st.session_state["defaults"].txt2vid.write_info_files = st.checkbox("Write Info Files For txt2vid Images", value=st.session_state['defaults'].txt2vid.write_info_files,
                                                                                     help="Choose to write the info files along with the generated images. Default: True")

--- a/scripts/sd_utils.py
+++ b/scripts/sd_utils.py
@@ -72,6 +72,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, Union
 from io import BytesIO
 from packaging import version
+from uuid import uuid4
 #import librosa
 from logger import logger, set_logger_verbosity, quiesce_logger
 #from loguru import logger

--- a/scripts/txt2vid.py
+++ b/scripts/txt2vid.py
@@ -43,7 +43,7 @@ from io import BytesIO
 import imageio
 from slugify import slugify
 
-from diffusers import StableDiffusionPipeline
+from diffusers import StableDiffusionPipeline, DiffusionPipeline
 from diffusers.schedulers import DDIMScheduler, LMSDiscreteScheduler, \
      PNDMScheduler
 
@@ -76,13 +76,13 @@ class plugin_info():
 
 @torch.no_grad()
 def diffuse(
-    pipe,
-    cond_embeddings, # text conditioning, should be (1, 77, 768)
-    cond_latents,    # image conditioning, should be (1, 4, 64, 64)
-    num_inference_steps,
-    cfg_scale,
-    eta,
-    ):
+        pipe,
+        cond_embeddings, # text conditioning, should be (1, 77, 768)
+        cond_latents,    # image conditioning, should be (1, 4, 64, 64)
+        num_inference_steps,
+        cfg_scale,
+        eta,
+        ):
 
 	torch_device = cond_latents.get_device()
 
@@ -199,14 +199,14 @@ def diffuse(
 				inference_progress = ""
 
 			percent = int(100 * float(i+1 if i+1 < st.session_state.sampling_steps else st.session_state.sampling_steps)/float(st.session_state.sampling_steps))
-			frames_percent = int(100 * float(st.session_state.current_frame if st.session_state.current_frame < st.session_state.max_frames else st.session_state.max_frames)/float(
-			    st.session_state.max_frames))
+			frames_percent = int(100 * float(st.session_state.current_frame if st.session_state.current_frame < st.session_state.max_duration_in_seconds else st.session_state.max_duration_in_seconds)/float(
+			    st.session_state.max_duration_in_seconds))
 
 			if "progress_bar_text" in st.session_state:
 				st.session_state["progress_bar_text"].text(
 				    f"Running step: {i+1 if i+1 < st.session_state.sampling_steps else st.session_state.sampling_steps}/{st.session_state.sampling_steps} "
 				    f"{percent if percent < 100 else 100}% {inference_progress}{duration:.2f}{speed} | "
-				        f"Frame: {st.session_state.current_frame + 1 if st.session_state.current_frame < st.session_state.max_frames else st.session_state.max_frames}/{st.session_state.max_frames} "
+				        f"Frame: {st.session_state.current_frame + 1 if st.session_state.current_frame < st.session_state.max_duration_in_seconds else st.session_state.max_duration_in_seconds}/{st.session_state.max_duration_in_seconds} "
 				        f"{frames_percent if frames_percent < 100 else 100}% {st.session_state.frame_duration:.2f}{st.session_state.frame_speed}"
 				)
 
@@ -255,20 +255,25 @@ def load_diffusers_model(weights_path,torch_device):
 					model_path = os.path.join("models", "diffusers", "stable-diffusion-v1-5")
 
 				if not os.path.exists(model_path + "/model_index.json"):
-					server_state["pipe"] = StableDiffusionPipeline.from_pretrained(
-							weights_path,
-							use_local_file=True,
-							use_auth_token=st.session_state["defaults"].general.huggingface_token,
-							torch_dtype=torch.float16 if st.session_state['defaults'].general.use_float16 else None,
-							revision="fp16" if not st.session_state['defaults'].general.no_half else None
+					server_state["pipe"] = DiffusionPipeline.from_pretrained(
+					        weights_path,
+					        use_local_file=True,
+					        use_auth_token=st.session_state["defaults"].general.huggingface_token,
+					        torch_dtype=torch.float16 if st.session_state['defaults'].general.use_float16 else None,
+					        revision="fp16" if not st.session_state['defaults'].general.no_half else None,
+					        safety_checker=None,  # Very important for videos...lots of false positives while interpolating
+					        custom_pipeline="interpolate_stable_diffusion",
 						)
-					StableDiffusionPipeline.save_pretrained(server_state["pipe"], model_path)
+
+					DiffusionPipeline.save_pretrained(server_state["pipe"], model_path)
 				else:
-					server_state["pipe"] = StableDiffusionPipeline.from_pretrained(
-							model_path,
-							use_local_file=True,
-							torch_dtype=torch.float16 if st.session_state['defaults'].general.use_float16 else None,
-							revision="fp16" if not st.session_state['defaults'].general.no_half else None
+					server_state["pipe"] = DiffusionPipeline.from_pretrained(
+					        model_path,
+					        use_local_file=True,
+					        torch_dtype=torch.float16 if st.session_state['defaults'].general.use_float16 else None,
+					        revision="fp16" if not st.session_state['defaults'].general.no_half else None,
+					        safety_checker=None,  # Very important for videos...lots of false positives while interpolating
+					        custom_pipeline="interpolate_stable_diffusion",
 						)
 
 				server_state["pipe"].unet.to(torch_device)
@@ -334,42 +339,42 @@ def save_video_to_disk(frames, seeds, sanitized_prompt, fps=6,save_video=True, o
 	return video_path
 #
 def txt2vid(
-	# --------------------------------------
-    # args you probably want to change
+        # --------------------------------------
+        # args you probably want to change
 	prompts = ["blueberry spaghetti", "strawberry spaghetti"], # prompt to dream about
 	gpu:int = st.session_state['defaults'].general.gpu, # id of the gpu to run on
 	#name:str = 'test', # name of this project, for the output directory
 	#rootdir:str = st.session_state['defaults'].general.outdir,
 	num_steps:int = 200, # number of steps between each pair of sampled points
-    max_frames:int = 10000, # number of frames to write and then exit the script
-    num_inference_steps:int = 50, # more (e.g. 100, 200 etc) can create slightly better images
-    cfg_scale:float = 5.0, # can depend on the prompt. usually somewhere between 3-10 is good
-    save_video = True,
-    save_video_on_stop = False,
-    outdir='outputs',
-    do_loop = False,
-    use_lerp_for_text = False,
-    seeds = None,
-    quality:int = 100, # for jpeg compression of the output images
-    eta:float = 0.0,
-    width:int = 256,
-    height:int = 256,
-    weights_path = "runwayml/stable-diffusion-v1-5",
-    scheduler="klms",  # choices: default, ddim, klms
-    disable_tqdm = False,
-    #-----------------------------------------------
-    beta_start = 0.0001,
-    beta_end = 0.00012,
-    beta_schedule = "scaled_linear",
-    starting_image=None
-    ):
+        max_duration_in_seconds:int = 30, # number of frames to write and then exit the script
+        num_inference_steps:int = 50, # more (e.g. 100, 200 etc) can create slightly better images
+        cfg_scale:float = 5.0, # can depend on the prompt. usually somewhere between 3-10 is good
+        save_video = True,
+        save_video_on_stop = False,
+        outdir='outputs',
+        do_loop = False,
+        use_lerp_for_text = False,
+        seeds = None,
+        quality:int = 100, # for jpeg compression of the output images
+        eta:float = 0.0,
+        width:int = 256,
+        height:int = 256,
+        weights_path = "runwayml/stable-diffusion-v1-5",
+        scheduler="klms",  # choices: default, ddim, klms
+        disable_tqdm = False,
+        #-----------------------------------------------
+        beta_start = 0.0001,
+        beta_end = 0.00012,
+        beta_schedule = "scaled_linear",
+        starting_image=None
+        ):
 	"""
 	prompt = ["blueberry spaghetti", "strawberry spaghetti"], # prompt to dream about
 	gpu:int = st.session_state['defaults'].general.gpu, # id of the gpu to run on
 	#name:str = 'test', # name of this project, for the output directory
 	#rootdir:str = st.session_state['defaults'].general.outdir,
 	num_steps:int = 200, # number of steps between each pair of sampled points
-	max_frames:int = 10000, # number of frames to write and then exit the script
+	max_duration_in_seconds:int = 10000, # number of frames to write and then exit the script
 	num_inference_steps:int = 50, # more (e.g. 100, 200 etc) can create slightly better images
 	cfg_scale:float = 5.0, # can depend on the prompt. usually somewhere between 3-10 is good
 	do_loop = False,
@@ -394,7 +399,7 @@ def txt2vid(
 
 	# We add an extra frame because most
 	# of the time the first frame is just the noise.
-	#max_frames +=1
+	#max_duration_in_seconds +=1
 
 	assert torch.cuda.is_available()
 	assert height % 8 == 0 and width % 8 == 0
@@ -420,7 +425,7 @@ def txt2vid(
 			        prompts = prompts,
 			        gpu = gpu,
 			        num_steps = num_steps,
-			        max_frames = max_frames,
+			        max_duration_in_seconds = max_duration_in_seconds,
 			        num_inference_steps = num_inference_steps,
 			        cfg_scale = cfg_scale,
 			        do_loop = do_loop,
@@ -530,19 +535,19 @@ def txt2vid(
 	st.session_state["total_frames_avg_speed"] = []
 
 	try:
-		while second_count < max_frames:
+		while second_count < max_duration_in_seconds:
 			st.session_state["frame_duration"] = 0
 			st.session_state["frame_speed"] = 0
 			st.session_state["current_frame"] = frame_index
 
-			#print(f"Second: {second_count+1}/{max_frames}")
+			#print(f"Second: {second_count+1}/{max_duration_in_seconds}")
 
 			# sample the destination
 			init2 = torch.randn((1, server_state["pipe"].unet.in_channels, height // 8, width // 8), device=torch_device)
 
 			for i, t in enumerate(np.linspace(0, 1, num_steps)):
 				start = timeit.default_timer()
-				logger.info(f"COUNT: {frame_index+1}/{max_frames}")
+				logger.info(f"COUNT: {frame_index+1}/{max_duration_in_seconds}")
 
 				if use_lerp_for_text:
 					init = torch.lerp(init1, init2, float(t))
@@ -629,9 +634,9 @@ def txt2vid(
 
 	info = f"""
 		{prompts}
-		Sampling Steps: {num_steps}, Sampler: {scheduler}, CFG scale: {cfg_scale}, Seed: {seeds}, Max Frames: {max_frames}""".strip()
+		Sampling Steps: {num_steps}, Sampler: {scheduler}, CFG scale: {cfg_scale}, Seed: {seeds}, Max Frames: {max_duration_in_seconds}""".strip()
 	stats = f'''
-		Took { round(time_diff, 2) }s total ({ round(time_diff/(max_frames),2) }s per image)
+		Took { round(time_diff, 2) }s total ({ round(time_diff/(max_duration_in_seconds),2) }s per image)
 		Peak memory usage: { -(mem_max_used // -1_048_576) } MiB / { -(mem_total // -1_048_576) } MiB / { round(mem_max_used/mem_total*100, 3) }%'''
 
 	return video_path, seeds, info, stats
@@ -676,7 +681,8 @@ def layout():
 					#It increases the VRAM usage a lot but if you have enough VRAM it can reduce the time it takes to finish generation as more images are generated at once.\
 					#Default: 1")
 
-			st.session_state["max_frames"] = st.number_input("Max Frames:", value=st.session_state['defaults'].txt2vid.max_frames, help="Specify the max number of frames you want to generate.")
+			st.session_state["max_duration_in_seconds"] = st.number_input("Max Duration In Seconds:", value=st.session_state['defaults'].txt2vid.max_duration_in_seconds,
+			                                                 help="Specify the max duration in seconds you want your video to be.")
 
 			with st.expander("Preview Settings"):
 				#st.session_state["update_preview"] = st.checkbox("Update Image Preview", value=st.session_state['defaults'].txt2vid.update_preview,
@@ -797,7 +803,9 @@ def layout():
 				st.session_state["write_info_files"] = st.checkbox("Write Info file", value=st.session_state['defaults'].txt2vid.write_info_files,
 					                                               help="Save a file next to the image with informartion about the generation.")
 
-				#st.session_state["do_loop"] = st.checkbox("Do Loop", value=st.session_state['defaults'].txt2vid.do_loop, help="Do loop")
+				st.session_state["do_loop"] = st.checkbox("Do Loop", value=st.session_state['defaults'].txt2vid.do_loop,
+				                                          help="Loop the prompt making two prompts from a single one.")
+
 				st.session_state["use_lerp_for_text"] = st.checkbox("Use Lerp Instead of Slerp", value=st.session_state['defaults'].txt2vid.use_lerp_for_text,
 				                                                    help="Uses torch.lerp() instead of slerp. When interpolating between related prompts. \
 				                                                    e.g. 'a lion in a grassy meadow' -> 'a bear in a grassy meadow' tends to keep the meadow \
@@ -938,11 +946,11 @@ def layout():
 		#try:
 		# run video generation
 		video, seed, info, stats = txt2vid(prompts=prompt, gpu=st.session_state["defaults"].general.gpu,
-	                                       num_steps=st.session_state.sampling_steps, max_frames=st.session_state.max_frames,
+		                                   num_steps=st.session_state.sampling_steps, max_duration_in_seconds=st.session_state.max_duration_in_seconds,
 		                                   num_inference_steps=st.session_state.num_inference_steps,
 		                                   cfg_scale=cfg_scale, save_video_on_stop=save_video_on_stop,
 		                                   outdir=st.session_state["defaults"].general.outdir,
-		                                   #do_loop=st.session_state["do_loop"],
+		                                   do_loop=st.session_state["do_loop"],
 		                                   use_lerp_for_text=st.session_state["use_lerp_for_text"],
 		                                   seeds=seed, quality=100, eta=0.0, width=width,
 		                                   height=height, weights_path=custom_model, scheduler=scheduler_name,

--- a/scripts/txt2vid.py
+++ b/scripts/txt2vid.py
@@ -327,7 +327,7 @@ def save_video_to_disk(frames, seeds, sanitized_prompt, fps=6,save_video=True, o
 		#output = io.BytesIO()
 		#writer = imageio.get_writer(os.path.join(os.getcwd(), st.session_state['defaults'].general.outdir, "txt2vid"), im, extension=".mp4", fps=30)
 		#try:
-		video_path = os.path.join(os.getcwd(), outdir, "txt2vid",f"{seeds}_{sanitized_prompt}.mp4")
+		video_path = os.path.join(os.getcwd(), outdir, "txt2vid",f"{seeds}_{sanitized_prompt}{datetime.now().strftime('%Y%m-%d%H-%M%S-') + str(uuid4())[:8]}.mp4")
 		writer = imageio.get_writer(video_path, fps=fps)
 		for frame in frames:
 			writer.append_data(frame)


### PR DESCRIPTION
- Updated diffusers to 0.6.0.
- Renamed `max_frames` to `max_duration_in_seconds` in txt2vid to reflect better what the option is currently doing.
- Moved txt2vid to use diffusers custom `interpolate_stable_diffusion` pipeline instead of `StableDiffusionPipeline`.
- Added safety checker which is disabled by default.
- Added unique 16-17 characters id to videos so they are not overridden when you create multiple videos with the same prompt and seed.
