### PR TITLE
Fixed typo in last command

### DIFF
--- a/Web_based_UI_for_Stable_Diffusion_colab.ipynb
+++ b/Web_based_UI_for_Stable_Diffusion_colab.ipynb
@@ -431,7 +431,7 @@
       "source": [
         "#@title Open port 8501 and start Streamlit server. Open link in 'link.txt' file in file pane on left.\n",
         "!npx localtunnel --port 8501 &>/content/link.txt &\n",
-        "!streamlit run scripts/webui_streamlit.py --theme.base dark --server.headless true true 2>&1 | tee -a /content/log.txt"
+        "!streamlit run scripts/webui_streamlit.py --theme.base dark --server.headless true 2>&1 | tee -a /content/log.txt"
       ],
       "metadata": {
         "id": "5whXm2nfSZ39"


### PR DESCRIPTION
# Description

changed:
"!streamlit run scripts/webui_streamlit.py --theme.base dark --server.headless true true 2>&1 | tee -a /content/log.txt"
to:
"!streamlit run scripts/webui_streamlit.py --theme.base dark --server.headless true 2>&1 | tee -a /content/log.txt" 
avoids 'unknown argument error'

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation