### PR TITLE
Add settings on the settings page to customize most streamlit options including the server address, port and headless mode.

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -36,6 +36,7 @@ enableWebsocketCompression = false
 [browser]
 gatherUsageStats = false
 serverPort = 8501
+serverAddress = "localhost"
 
 [mapbox]
 token = ""

--- a/scripts/Settings.py
+++ b/scripts/Settings.py
@@ -208,14 +208,64 @@ def layout():
             with col4:
                 st.title("Streamlit Config")
 
-                st.session_state["defaults"].general.streamlit_telemetry = st.checkbox("Enable Telemetry", value=st.session_state['defaults'].general.streamlit_telemetry,
-                                                                                       help="Enables or Disables streamlit telemetry. Default: False")
-                st.session_state["streamlit_config"]["browser"]["gatherUsageStats"] = st.session_state["defaults"].general.streamlit_telemetry
-
                 default_theme_list = ["light", "dark"]
                 st.session_state["defaults"].general.default_theme = st.selectbox("Default Theme", default_theme_list, index=default_theme_list.index(st.session_state['defaults'].general.default_theme),
                                                                                   help="Defaut theme to use as base for streamlit. Default: dark")
                 st.session_state["streamlit_config"]["theme"]["base"] = st.session_state["defaults"].general.default_theme
+
+                with st.expander("Server", True):
+
+                    st.session_state["streamlit_config"]['server']['headless'] = st.checkbox("Run Headless", help="If false, will attempt to open a browser window on start.  \
+                                                                                             Default: false unless (1) we are on a Linux box where DISPLAY is unset, \
+                                                                                             or (2) we are running in the Streamlit Atom plugin.")
+
+                    st.session_state["streamlit_config"]['server']['port'] = st.number_input("Port", value=st.session_state["streamlit_config"]['server']['port'],
+                                                                                             help="The port where the server will listen for browser connections. Default: 8501")
+
+                    st.session_state["streamlit_config"]['server']['baseUrlPath'] = st.text_input("Base Url Path", value=st.session_state["streamlit_config"]['server']['baseUrlPath'],
+                                                                                             help="The base path for the URL where Streamlit should be served from. Default: '' ")
+
+                    st.session_state["streamlit_config"]['server']['enableCORS'] = st.checkbox("Enable CORS", value=st.session_state['streamlit_config']['server']['enableCORS'],
+                                                                                               help="Enables support for Cross-Origin Request Sharing (CORS) protection, for added security. \
+                                                                                               Due to conflicts between CORS and XSRF, if `server.enableXsrfProtection` is on and `server.enableCORS` \
+                                                                                               is off at the same time, we will prioritize `server.enableXsrfProtection`. Default: true")
+
+                    st.session_state["streamlit_config"]['server']['enableXsrfProtection'] = st.checkbox("Enable Xsrf Protection",
+                                                                                                         value=st.session_state['streamlit_config']['server']['enableXsrfProtection'],
+                                                                                                         help="Enables support for Cross-Site Request Forgery (XSRF) protection, \
+                                                                                                         for added security. Due to conflicts between CORS and XSRF, \
+                                                                                                         if `server.enableXsrfProtection` is on and `server.enableCORS` is off at \
+                                                                                                         the same time, we will prioritize `server.enableXsrfProtection`. Default: true")
+
+                    st.session_state["streamlit_config"]['server']['maxUploadSize'] = st.number_input("Max Upload Size", value=st.session_state["streamlit_config"]['server']['maxUploadSize'],
+                                                                                             help="Max size, in megabytes, for files uploaded with the file_uploader. Default: 200")
+
+                    st.session_state["streamlit_config"]['server']['maxMessageSize'] = st.number_input("Max Message Size", value=st.session_state["streamlit_config"]['server']['maxUploadSize'],
+                                                                                             help="Max size, in megabytes, of messages that can be sent via the WebSocket connection. Default: 200")
+
+                    st.session_state["streamlit_config"]['server']['enableWebsocketCompression'] = st.checkbox("Enable Websocket Compression",
+                                                                                                               value=st.session_state["streamlit_config"]['server']['enableWebsocketCompression'],
+                                                                                                               help=" Enables support for websocket compression. Default: false")
+                with st.expander("Browser", expanded=True):
+                    st.session_state["streamlit_config"]['browser']['serverAddress'] = st.text_input("Server Address",
+                                                                                                   value=st.session_state["streamlit_config"]['browser']['serverAddress'],
+                                                                                                   help="Internet address where users should point their browsers in order \
+                                                                                                   to connect to the app. Can be IP address or DNS name and path.\
+                                                                                                   This is used to: - Set the correct URL for CORS and XSRF protection purposes. \
+                                                                                                   - Show the URL on the terminal - Open the browser. Default: 'localhost'")
+
+                    st.session_state["defaults"].general.streamlit_telemetry = st.checkbox("Enable Telemetry", value=st.session_state['defaults'].general.streamlit_telemetry,
+                                                                                           help="Enables or Disables streamlit telemetry. Default: False")
+                    st.session_state["streamlit_config"]["browser"]["gatherUsageStats"] = st.session_state["defaults"].general.streamlit_telemetry
+
+                    st.session_state["streamlit_config"]['browser']['serverPort'] = st.number_input("Server Port", value=st.session_state["streamlit_config"]['browser']['serverPort'],
+                                                                                             help="Port where users should point their browsers in order to connect to the app. \
+                                                                                             This is used to: - Set the correct URL for CORS and XSRF protection purposes. \
+                                                                                             - Show the URL on the terminal - Open the browser \
+                                                                                             Default: whatever value is set in server.port.")
+
+
+
 
             with col5:
                 st.title("Huggingface")

--- a/webui.cmd
+++ b/webui.cmd
@@ -99,10 +99,10 @@ call "%v_conda_path%\Scripts\activate.bat" "%v_conda_env_name%"
 :PROMPT
 set SETUPTOOLS_USE_DISTUTILS=stdlib
 IF EXIST "models\ldm\stable-diffusion-v1\Stable Diffusion v1.5.ckpt" (
-  python -m streamlit run scripts\webui_streamlit.py --theme.base dark --server.address localhost
+  python -m streamlit run scripts\webui_streamlit.py --theme.base dark
 ) ELSE (
   echo Your model file does not exist! Once the WebUI launches please visit the Model Manager page and download the models by using the Download button for each model.
-  python -m streamlit run scripts\webui_streamlit.py --theme.base dark --server.address localhost
+  python -m streamlit run scripts\webui_streamlit.py --theme.base dark
 )
 
 ::cmd /k

--- a/webui.sh
+++ b/webui.sh
@@ -148,12 +148,12 @@ launch_webui () {
     done
     printf "\n\n########## LAUNCH USING STREAMLIT OR GRADIO? ##########\n\n"
     printf "Do you wish to run the WebUI using the Gradio or StreamLit Interface?\n\n"
-    printf "Streamlit: \nHas A More Modern UI \nMore Features Planned \nWill Be The Main UI Going Forward \nCurrently In Active Development \nMissing Some Gradio Features\n\n"
+    printf "Streamlit: \nHas A More Modern UI \nMore Features Planned \nWill Be The Main UI Going Forward \nCurrently In Active Development \n\n"
     printf "Gradio: \nCurrently Feature Complete \nUses An Older Interface Style \nWill Not Receive Major Updates\n\n"
     printf "Which Version of the WebUI Interface do you wish to use?\n"
     select yn in "Streamlit" "Gradio"; do
         case $yn in
-            Streamlit ) printf "\nStarting Stable Diffusion WebUI: Streamlit Interface. Please Wait...\n"; python -m streamlit run scripts/webui_streamlit.py --theme.base dark --server.address localhost; break;;
+            Streamlit ) printf "\nStarting Stable Diffusion WebUI: Streamlit Interface. Please Wait...\n"; python -m streamlit run scripts/webui_streamlit.py; break;;
             Gradio ) printf "\nStarting Stable Diffusion WebUI: Gradio Interface. Please Wait...\n"; python scripts/relauncher.py "$@"; break;;
         esac
     done


### PR DESCRIPTION
- Add settings on the settings page to customize most streamlit options including the server address, port and headless mode.
- Changed default server address to localhost.
- Removed default hard coded server address from the cmd and sh file as they are now customizable through the Settings page on the streamlit version.
