### PR TITLE
Fixed errors when post-processing models aren't installed

### DIFF
--- a/scripts/img2img.py
+++ b/scripts/img2img.py
@@ -545,7 +545,9 @@ def layout():
 									upscaling_method_list.append("LDSR")
 
 								st.session_state["upscaling_method"] = st.selectbox("Upscaling Method", upscaling_method_list,
-																								index=upscaling_method_list.index(st.session_state['defaults'].general.upscaling_method))
+                                                                                               index=upscaling_method_list.index(st.session_state['defaults'].general.upscaling_method)
+                                                                                                    if st.session_state['defaults'].general.upscaling_method in upscaling_method_list
+                                                                                                    else 0)
 
 								if st.session_state["RealESRGAN_available"]:
 									with st.expander("RealESRGAN"):

--- a/scripts/sd_utils.py
+++ b/scripts/sd_utils.py
@@ -2010,6 +2010,8 @@ def GFPGAN_available():
         st.session_state["GFPGAN_available"] = True
     else:
         st.session_state["GFPGAN_available"] = False
+        st.session_state["use_GFPGAN"] = False
+        st.session_state["GFPGAN_model"] = "GFPGANv1.4"
 
 #
 def RealESRGAN_available():
@@ -2028,6 +2030,8 @@ def RealESRGAN_available():
         st.session_state["RealESRGAN_available"] = True
     else:
         st.session_state["RealESRGAN_available"] = False
+        st.session_state["use_RealESRGAN"] = False
+        st.session_state["RealESRGAN_model"] = "RealESRGAN_x4plus"
 #
 def LDSR_available():
     #with server_state_lock["RealESRGAN_models"]:
@@ -2048,6 +2052,8 @@ def LDSR_available():
         st.session_state["LDSR_available"] = True
     else:
         st.session_state["LDSR_available"] = False
+        st.session_state["use_LDSR"] = False
+        st.session_state["LDSR_model"] = "model"
 
 
 

--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -570,7 +570,9 @@ def layout():
 
                                 #print (st.session_state["RealESRGAN_available"])
                                 st.session_state["upscaling_method"] = st.selectbox("Upscaling Method", upscaling_method_list,
-                                                                                    index=upscaling_method_list.index(str(st.session_state['defaults'].general.upscaling_method)))
+                                                                                    index=upscaling_method_list.index(st.session_state['defaults'].general.upscaling_method)
+                                                                                        if st.session_state['defaults'].general.upscaling_method in upscaling_method_list
+                                                                                        else 0)
 
                                 if st.session_state["RealESRGAN_available"]:
                                     with st.expander("RealESRGAN"):

--- a/scripts/txt2vid.py
+++ b/scripts/txt2vid.py
@@ -1788,7 +1788,9 @@ def layout():
                                 upscaling_method_list.append("LDSR")
 
                             st.session_state["upscaling_method"] = st.selectbox("Upscaling Method", upscaling_method_list,
-                                                                                                            index=upscaling_method_list.index(st.session_state['defaults'].general.upscaling_method))
+                                                                                                            index=upscaling_method_list.index(st.session_state['defaults'].general.upscaling_method)
+                                                                                                                if st.session_state['defaults'].general.upscaling_method in upscaling_method_list
+                                                                                                                else 0)
 
                             if st.session_state["RealESRGAN_available"]:
                                 with st.expander("RealESRGAN"):


### PR DESCRIPTION
Fixes #1522, #1604, #1453

LDSR changes in 0c03cedeb9131b0b5d6c1dd280c966ae00fca787 don't always set the session_state keys depending on which combination of post processing models are installed.
Resolves errors such as 
`KeyError: 'st.session_state has no key "use_LDSR"`
`KeyError: 'st.session_state has no key "GFPGAN_model"`

sd_utils changes set these values to defaults when available check fails
The other changes prevent errors if LDSR is installed without RealESRGAN eg:
`File "scripts\txt2vid.py", line 1788, in layout
    index=upscaling_method_list.index(st.session_state['defaults'].general.upscaling_method))
ValueError: 'RealESRGAN' is not in list`
