### PR TITLE
Fix Conda environment for correct PyTorch installation

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -15,14 +15,13 @@ name: ldm
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 channels:
-  - conda-forge
   - pytorch
   - defaults
   - nvidia
 # Psst. If you change a dependency, make sure it's mirrored in the docker requirement
 # files as well.
 dependencies:
-  - nodejs=18.11.0
+  - conda-forge::nodejs=18.11.0
   - yarn=1.22.19
   - cudatoolkit=11.3
   - git


### PR DESCRIPTION
# Description

The recent addition of the `conda-forge` channel to `environment.yaml` causes PyTorch to be installed from that channel, which prevents normal functionality since that version of PyTorch does not support CUDA at all.

This PR limits `conda-forge` to be only used for NodeJS, fixing the PyTorch installation issue.

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code

N/A:

- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation