### PR TITLE
Stop text2vid at total_frames

### DIFF
--- a/scripts/txt2vid.py
+++ b/scripts/txt2vid.py
@@ -1056,7 +1056,6 @@ def diffuse(
                 speed = "it/s"
                 duration = 1 / duration
 
-            # perhaps add an option to set fps within the ui eventually
             total_frames = st.session_state.max_duration_in_seconds * fps
             total_steps = st.session_state.sampling_steps + st.session_state.num_inference_steps
 

--- a/scripts/txt2vid.py
+++ b/scripts/txt2vid.py
@@ -1585,6 +1585,8 @@ def txt2vid(
 
                 st.session_state["frame_duration"] = duration
                 st.session_state["frame_speed"] = speed
+                if frame_index+1 > total_frames:
+                    break
 
             init1 = init2
 


### PR DESCRIPTION
# Description
Frame generation is being done in chunks of the number of samples chosen, so when you needed 120 frames but set 200 samples, it would generate 200 frames.

* Added a break to stop frames from generating once total_frames is reached

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation