### PR TITLE
Fixed different typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Check the [Contribution Guide](CONTRIBUTING.md)
 
 * Run additional upscaling models on CPU to save VRAM
 
-* Textual inversion: [Reaserch Paper](https://textual-inversion.github.io/) 
+* Textual inversion: [Research Paper](https://textual-inversion.github.io/) 
 
 * K-Diffusion Samplers: A great collection of samplers to use, including:
   


### PR DESCRIPTION
# Description
Found and fixed another typo in the README.md.
Hyperlink was spelled "Reaserch" instead of correct spelling of "Research".
No additional dependencies.

Please include:
* relevant motivation
* a summary of the change
* which issue is fixed.
* any additional dependencies that are required for this change.

Closes: # (issue)

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation