### PR TITLE
Adding back deleted docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.9'
+
+services:
+  stable-diffusion:
+    container_name: sd-webui
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file: .env_docker
+    environment:
+      PIP_EXISTS_ACTION: w
+    volumes:
+      - .:/sd
+      - ./outputs:/sd/outputs
+      - ./model_cache:/sd/model_cache
+      - conda_env:/opt/conda
+      - root_profile:/root
+    ports:
+      - '7860:7860'
+      - '8501:8501'
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [ gpu ]
+
+volumes:
+  conda_env:
+  root_profile:


### PR DESCRIPTION
# Description

Please include:
I'm not sure why this `docker-compose.yml` was deleted in the first place. Nearly half of the instructions in the readme for this repo rely on this file being there. 

Essentially, it's just another way to start up the container using `docker compose` . This makes the container much more usable for power users, as they'd be able to configure volumes much easier. Also, instead of having to remember the whole complicated `docker container run --rm -d -p 8501:8501 -e STREAMLIT_SERVER_HEADLESS=true -e "WEBUI_SCRIPT=webui_streamlit.py" -e "VALIDATE_MODELS=false" -v "${PWD}/outputs:/sd/outputs" --gpus all tukirito/sygil-webui:latest` command, it's as simple as running `docker compose start` or `up`, since all of the configs are in the compose file, you wouldn't need anything else. The compose file has been tested and runs without any issues. The readme instructions can stay mostly as is. 

Additionally, as mentioned before, the readme instructions rely heavily on docker compose. If the repo creators wish to not include docker compose, then it should all be omitted from the readme, as it makes this extremely confusing for any user. 

Closes: # (issue)

# Checklist:

- [ ] I have changed the base branch to `dev`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
