### PR TITLE
Use id rather than modelId from Hugging Face

### DIFF
--- a/scripts/sd_concepts_library_downloader.py
+++ b/scripts/sd_concepts_library_downloader.py
@@ -32,7 +32,7 @@ models = []
 print("Downloading the sd concept library from the huggingface site.")
 for model in models_list:
     model_content = {}
-    model_id = model.modelId
+    model_id = model.id
     url = f"https://huggingface.co/{model_id}"
     try:
         if not os.path.exists(os.path.join("../models/custom", model_id)):


### PR DESCRIPTION
# Description

For context, modelId is getting deprecated https://github.com/huggingface/huggingface_hub/issues/2408
Closes: # (issue)

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
